### PR TITLE
Adds travis configuration (#10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+language: ruby
+rvm:
+  - 2.3.4
+
+script:
+  - bundle exec jekyll build
+
+deploy:
+  provider: s3
+  # AWS credentials can be manually re/configured using the travis-ci command
+  # line tool:
+  #
+  #     $ travis setup s3
+  #
+  bucket: www.scalabridge.org
+  skip_cleanup: true
+  local_dir: _site

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-ruby "2.3.1"
+ruby '2.3.4'
 
 gem 'jekyll', '~> 3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ DEPENDENCIES
   jekyll (~> 3)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.4p301
 
 BUNDLED WITH
-   1.12.5
+   1.15.4

--- a/_config.yml
+++ b/_config.yml
@@ -13,4 +13,6 @@ markdown: kramdown
 exclude:
   - Gemfile
   - Gemfile.lock
-  - s3_website.yml
+  - vendor
+  - LICENSE
+  - README.md


### PR DESCRIPTION
www.scalabridge.org can now be automatically built and deployed using
Travis CI. Before builds are enabled, a scalabridge contributor will
need to:

  1. [x] [Activate the project on travis-ci](https://travis-ci.org/scalabridge/website)

  2. [ ] Add S3 credentials with write access to the website bucket (see
    also #9) using [the travis CLI](https://docs.travis-ci.com/user/deployment/s3/)